### PR TITLE
Use LibreOffice From Flatpak

### DIFF
--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -26,6 +26,7 @@
   loop:
     - org.mozilla.Thunderbird
     - org.gnome.Geary
+    - org.libreoffice.LibreOffice
     - com.discordapp.Discord
     - org.telegram.desktop
     - io.lbry.lbry-app
@@ -176,4 +177,5 @@
     - steam
     - vscode
     - code
+    - '"*"libreoffice"*"'
     state: absent

--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -177,5 +177,5 @@
     - steam
     - vscode
     - code
-    - '"*"libreoffice"*"'
+    - '*libreoffice*'
     state: absent


### PR DESCRIPTION
Allows running a more current and consistent version across all workstations.