### PR TITLE
Fix GNOME Install For Ubuntu 20.04

### DIFF
--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -178,4 +178,5 @@
     - vscode
     - code
     - '*libreoffice*'
+    - gimp
     state: absent

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -15,13 +15,13 @@
       - gnome 
       - gdm3
     state: present
-  when: gnome_install is defined and gnome_install.failed is define gnome_install.failed
+  when: gnome_install is defined and gnome_install.failed is defined and gnome_install.failed
 
 - name: Workstation | Linux | Software | GNOME | Note Before Exiting
   debug:
     msg: "You will need to run `dpkg-reconfigure gdm3` to ensure gdm3 is selected."
-  when: gnome_install is defined and gnome_install.failed is define gnome_install.failed
+  when: gnome_install is defined and gnome_install.failed is defined and gnome_install.failed
 
 - name: Workstation | Linux | Software | GNOME | Exiting
   shell: exit 1
-  when: gnome_install is defined and gnome_install.failed is define gnome_install.failed
+  when: gnome_install is defined and gnome_install.failed is defined and gnome_install.failed

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -21,7 +21,7 @@
 
 - name: Workstation | Linux | Software | GNOME | Note Before Exiting
   debug:
-    msg: "You will probably need to run `dpkg-reconfigure gdm3` to ensure gdm3 is selected."
+    msg: "You will need to run `dpkg-reconfigure gdm3` to ensure gdm3 is selected."
   when: gnome_install is defined and gnome_install.failed
 
 - name: Workstation | Linux | Software | GNOME | Exiting

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -1,8 +1,8 @@
 # Some Linux distros come with meh DE's, this fixes that.
 
 - name: Workstation | Linux | Software | GNOME | Bypass for other other OS's
-  set_fact:
-    gnome_install.failed: false
+  shell: which htop
+  register: gnome_install
   when: ansible_distribution not in ("Parrot OS")
 
 - name: Workstation | Linux | Software | GNOME | Check (Parrot OS Only)

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -1,7 +1,7 @@
 # Some Linux distros come with meh DE's, this fixes that.
 
 - name: Workstation | Linux | Software | GNOME | Bypass for other other OS's
-  set_fact: which gdm3
+  set_fact:
     gnome_install.failed: false
   when: ansible_distribution not in ("Parrot OS")
 

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -11,6 +11,9 @@
   when: ansible_distribution in ("Parrot OS")
   ignore_errors: true
 
+- debug:
+    var: gnome_install
+
 - name: Workstation | Linux | Software | GNOME | Install
   package:
     name: 

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -6,9 +6,6 @@
   when: ansible_distribution in ("Parrot OS")
   ignore_errors: true
 
-- debug:
-    var: gnome_install
-
 - name: Workstation | Linux | Software | GNOME | Install
   package:
     name: 

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -1,10 +1,5 @@
 # Some Linux distros come with meh DE's, this fixes that.
 
-- name: Workstation | Linux | Software | GNOME | Bypass for other other OS's
-  shell: which htop
-  register: gnome_install
-  when: ansible_distribution not in ("Parrot OS")
-
 - name: Workstation | Linux | Software | GNOME | Check (Parrot OS Only)
   shell: which gdm3
   register: gnome_install
@@ -20,13 +15,13 @@
       - gnome 
       - gdm3
     state: present
-  when: gnome_install is defined and gnome_install.failed
+  when: gnome_install is defined and gnome_install.failed is define gnome_install.failed
 
 - name: Workstation | Linux | Software | GNOME | Note Before Exiting
   debug:
     msg: "You will need to run `dpkg-reconfigure gdm3` to ensure gdm3 is selected."
-  when: gnome_install is defined and gnome_install.failed
+  when: gnome_install is defined and gnome_install.failed is define gnome_install.failed
 
 - name: Workstation | Linux | Software | GNOME | Exiting
   shell: exit 1
-  when: gnome_install is defined and gnome_install.failed
+  when: gnome_install is defined and gnome_install.failed is define gnome_install.failed

--- a/tasks/workstation/linux/software/gnome.yml
+++ b/tasks/workstation/linux/software/gnome.yml
@@ -1,5 +1,10 @@
 # Some Linux distros come with meh DE's, this fixes that.
 
+- name: Workstation | Linux | Software | GNOME | Bypass for other other OS's
+  set_fact: which gdm3
+    gnome_install.failed: false
+  when: ansible_distribution not in ("Parrot OS")
+
 - name: Workstation | Linux | Software | GNOME | Check (Parrot OS Only)
   shell: which gdm3
   register: gnome_install
@@ -12,11 +17,6 @@
       - gnome 
       - gdm3
     state: present
-  when: gnome_install is defined and gnome_install.failed
-
-- name: Workstation | Linux | Software | GNOME | TEST
-  debug:
-    var: gnome_install
   when: gnome_install is defined and gnome_install.failed
 
 - name: Workstation | Linux | Software | GNOME | Note Before Exiting

--- a/tasks/workstation/settings/gnome.yml
+++ b/tasks/workstation/settings/gnome.yml
@@ -21,9 +21,9 @@
 - name: Workstation | Account Management | GNOME | Install Dependencies
   package:
     name: 
-    - "{{ gnome_tweaks }}"
-    - "{{ dconf_editor }}"
-    - "{{ psutil }}"
+      - "{{ gnome_tweaks }}"
+      - "{{ dconf_editor }}"
+      - "{{ psutil }}"
     state: present
 
 
@@ -47,12 +47,19 @@
     force: no
     version: master
   become_user: ling
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
+
+- name: Workstation | Account Management | GNOME | Dash To Dock | Install | Dependencies
+  package:
+    name: 
+      - make
+    state: present
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Install | Make
   shell: "cd ~/TRASH/dash-to-dock/; make; make install"
   become_user: ling
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Read Enabled Extension Array
   dconf: 
@@ -60,12 +67,12 @@
     state: read
   become_user: ling
   register: gnome_enabled_extensions
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | dconf Return Object
   debug:
     var: gnome_enabled_extensions
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 # https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/playbooks_filters.html#filters-for-formatting-data
 
@@ -73,42 +80,42 @@
   set_fact: 
     gnome_enabled_extensions: "{{ gnome_enabled_extensions.value | replace('@as ', '') }}"
     dash_to_dock_ext_comma: ""
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | After replace()
   debug:
     var: gnome_enabled_extensions
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Variables 2
   set_fact: 
     dash_to_dock_ext_comma: ", "
-  when: dash_to_dock_exists.failed and gnome_enabled_extensions not in ("[]", [], "None")
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed and gnome_enabled_extensions not in ("[]", [], "None")
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Variables 3
   set_fact: 
     dash_to_dock_ext_name: "{{ dash_to_dock_ext_comma }}'dash-to-dock@micxgx.gmail.com']"
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Variables 4
   set_fact:
     gnome_enabled_extensions: "[]"
-  when: dash_to_dock_exists.failed and gnome_enabled_extensions == "None"
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed and gnome_enabled_extensions == "None"
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Print Value To Append With
   debug:
     var: dash_to_dock_ext_name
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Print Value To Append To
   debug:
     var: gnome_enabled_extensions
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Print Combined Value
   debug:
     msg: "{{ gnome_enabled_extensions | replace(']', dash_to_dock_ext_name) }}"
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 - name: Workstation | Account Management | GNOME | Dash To Dock | Enable
   dconf: 
@@ -116,7 +123,7 @@
     value: "{{ gnome_enabled_extensions | replace(']', dash_to_dock_ext_name) }}"
     state: present
   become_user: ling
-  when: dash_to_dock_exists.failed
+  when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
 # Settings #
 


### PR DESCRIPTION
Install was failing due to Ansible trying to check attribute failed on gnome_install. Settings file was then also failing due to `make` program not existing. Ubuntu must not use the default Dash To Dock install directory, so excluded it from needing the plugin.