### PR TITLE
Better `update` consistency between Parrot and non-Parrot.

### DIFF
--- a/facts/general/package.yml
+++ b/facts/general/package.yml
@@ -41,7 +41,9 @@
       echo "*** Apt ***" &&
       sudo apt update &&
       sudo apt autoremove {{ update_accept_var }} && 
-      sudo apt dist-upgrade {{ update_accept_var }} &&
+      sudo dpkg --configure -a &&
+      sudo apt --fix-broken --fix-missing install &&
+      sudo apt dist-upgrade --allow-downgrades --fix-broken --fix-missing {{ update_accept_var }} &&
   when: ansible_pkg_mgr == "apt"
 
 - name: General | Facts | Package | Update Commands | pacman
@@ -62,8 +64,10 @@
 - name: General | Facts | Package | Update Commands | parrot-upgrade
   set_fact:
     update_package_manager: |
-      parrot_mirrors_suck=true
       echo "*** Parrot ***"
+      sudo apt update &&
+      sudo apt autoremove &&
+      parrot_mirrors_suck=true &&
       while [[ $parrot_mirrors_suck ]]; do
         unset parrot_mirrors_suck
         sudo parrot-upgrade

--- a/facts/general/package.yml
+++ b/facts/general/package.yml
@@ -66,7 +66,7 @@
     update_package_manager: |
       echo "*** Parrot ***"
       sudo apt update &&
-      sudo apt autoremove &&
+      sudo apt autoremove {{ update_accept_var }} &&
       parrot_mirrors_suck=true &&
       while [[ $parrot_mirrors_suck ]]; do
         unset parrot_mirrors_suck


### PR DESCRIPTION
Add autoremove to Parrot and add the dpkg and apt fixes for broken packages to non-Parrot.