### PR TITLE
Go back to Evolution over Thunderbird

### DIFF
--- a/facts/workstation/package.yml
+++ b/facts/workstation/package.yml
@@ -18,6 +18,7 @@
     dconf_editor: dconf-editor
     appimagelauncher: htop #placeholder
     nfs: nfs-common
+    msgfmt: gettext
 
 
 - name: Workstation | Facts | Package | Pop_OS!

--- a/tasks/workstation/freebsd/software/gui.yml
+++ b/tasks/workstation/freebsd/software/gui.yml
@@ -7,7 +7,7 @@
     - xorg
     - gnome3-lite
     - "{{ firefox_esr }}"
-    - "{{ thunderbird }}"
+    - "{{ evolution }}"
     - vscode
     - gimp
     - telegram-desktop
@@ -17,7 +17,7 @@
   package: 
     name:
     - "{{ firefox }}"
-    - "{{ evolution }}"
+    - "{{ thunderbird }}"
     state: absent
 
 - name: Workstation | FreeBSD | GUI | Create rc.conf Entries

--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -117,6 +117,7 @@
     - com.visualstudio.code-oss
     - org.midori_browser.Midori
     - com.github.Eloston.UngoogledChromium
+    - org.gnome.Evolution # Doesn't pick up GNOME theme while contained.
   ignore_errors: yes
 
 
@@ -129,6 +130,7 @@
       - "{{ firefox_esr }}"
       - vlc
       - "{{ appimagelauncher }}"
+      - "{{ evolution }}"
     state: present
 
 - name: Workstation | Linux | Flatpak Distro | Package Manager | Remove Firefox Normal

--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -136,6 +136,7 @@
   package: 
     name: 
       - "{{ evolution }}"
+      - "{{ evolution }}*"
     state: present
 
 - name: Workstation | Linux | Flatpak Distro | Package Manager | Remove Firefox Normal

--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -130,7 +130,7 @@
       - "{{ firefox_esr }}"
       - vlc
       - "{{ appimagelauncher }}"
-      - "{{ evolution }}"
+      - "{{ evolution }}*"
     state: present
 
 - name: Workstation | Linux | Flatpak Distro | Package Manager | Remove Firefox Normal

--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -117,7 +117,7 @@
     - com.visualstudio.code-oss
     - org.midori_browser.Midori
     - com.github.Eloston.UngoogledChromium
-    - org.gnome.Evolution # Doesn't pick up GNOME theme while contained.
+    - org.gnome.Evolution # Doesn't pick up GNOME theme since contained.
   ignore_errors: yes
 
 

--- a/tasks/workstation/linux/software/flatpaks.yml
+++ b/tasks/workstation/linux/software/flatpaks.yml
@@ -130,7 +130,12 @@
       - "{{ firefox_esr }}"
       - vlc
       - "{{ appimagelauncher }}"
-      - "{{ evolution }}*"
+    state: present
+
+- name: Workstation | Linux | Flatpak Distro | Package Manager | Update From Repo
+  package: 
+    name: 
+      - "{{ evolution }}"
     state: present
 
 - name: Workstation | Linux | Flatpak Distro | Package Manager | Remove Firefox Normal

--- a/tasks/workstation/settings/gnome.yml
+++ b/tasks/workstation/settings/gnome.yml
@@ -53,6 +53,7 @@
   package:
     name: 
       - make
+      - "{{ msgfmt }}"
     state: present
   when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 

--- a/tasks/workstation/settings/gnome.yml
+++ b/tasks/workstation/settings/gnome.yml
@@ -153,7 +153,7 @@
   dconf: 
     key: /org/gnome/shell/favorite-apps
     value: "['org.gnome.Terminal.desktop', 'gnome-system-monitor.desktop', 'org.gnome.Nautilus.desktop', 
-             '{{ browser }}', 'org.mozilla.Thunderbird.desktop',
+             '{{ browser }}', 'org.gnome.Evolution.desktop', 'org.mozilla.Thunderbird.desktop',
              'com.vscodium.codium.desktop', 'org.shotcut.Shotcut.desktop', 
              'org.telegram.desktop.desktop', 'com.discordapp.Discord.desktop', 
              'rhythmbox.desktop', 'io.lbry.lbry-app.desktop',
@@ -166,7 +166,7 @@
   dconf: 
     key: /org/gnome/shell/favorite-apps
     value: "['org.gnome.Terminal.desktop', 'org.gnome.Nautilus.desktop', 
-             'firefox.desktop', 'org.mozilla.Thunderbird.desktop', 
+             'firefox.desktop', 'org.gnome.Evolution.desktop', 'org.mozilla.Thunderbird.desktop', 
              'code-oss.desktop', 'org.telegram.desktop.desktop']"
     state: present
   become_user: ling

--- a/tasks/workstation/settings/gnome.yml
+++ b/tasks/workstation/settings/gnome.yml
@@ -256,7 +256,7 @@
 
 # Schemas to try after looking at gsettings list-schemas | sort
 # org.gnome.ControlCenter -- not very interesting
-# org.gnome.desktop.default-applications -- nothing?? Where do we set Firefox and Evolution?
+# org.gnome.desktop.default-applications -- nothing?? Where do we set Brave and Evolution?
 # org.gnome.desktop.interface -- Good stuff in here.
 # org.gnome.desktop.peripherals -- Nothing :(
 # org.gnome.desktop.privacy -- Good stuff here too!! Cool!


### PR DESCRIPTION
Thunderbird has been a poor user experience with its tabs and lack of natural dark theme or card/caldav support. Adding Evolution back as a primary and will likely drop Thunderbird support once all workstations have been moved from Parrot Security OS to Debian Sid.