### PR TITLE
Fix Sudo On OpenSUSE

### DIFF
--- a/facts/general/system.yml
+++ b/facts/general/system.yml
@@ -25,6 +25,7 @@
   set_fact:
     rc_conf: /dev/null
     sudoers_install_dir: /etc/sudoers.d/
+    sudoers_config: /etc/sudoers
     shutdown_command: sudo shutdown -h now
   when: ansible_system == "Linux"
 

--- a/tasks/general/acct_mgmt/sudo.yml
+++ b/tasks/general/acct_mgmt/sudo.yml
@@ -16,3 +16,18 @@
     owner: root
     group: "{{ root_group }}"
     mode: 0440
+
+# Disable these two lines in openSUSE default configuration.
+#Defaults targetpw   # ask for the password of the target user i.e. root
+#ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+- name: General | Account Management | Sudo | Disable openSUSE Root PW Prompt
+  lineinfile:
+    path: "{{ sudoers_config }}"
+    regexp: '{{ item.key }}'
+    line: '{{ item.value }} # MANAGED BY ANSIBLE'
+    state: present
+    create: yes
+    backup: yes
+  loop:
+    - { "key": '^[\#]?Defaults targetpw',   "value": '#Defaults targetpw'}
+    - { "key": '^[\#]?ALL   ALL\=\(ALL\) ALL', "value": '#ALL   ALL=(ALL) ALL'}


### PR DESCRIPTION
Disable configuration which requests root password. This was preventing the normal usage of /etc/sudoers.d/sudoers_sudo.