### PR TITLE
Goodbye Google Browsers, Enhance Compress Video Script

### DIFF
--- a/files/scripts/compress-video.sh
+++ b/files/scripts/compress-video.sh
@@ -4,7 +4,7 @@
 
 DIR=`dirname $0`
 PROG=`basename $0`
-if [[ $DIR == '.' ]]; then
+if [[ "$DIR" == '.' ]]; then
 	DIR=`pwd`
 fi
 echo "Running $DIR/$PROG"
@@ -13,13 +13,13 @@ echo "Running $DIR/$PROG"
 
 function usage {
 	echo "Usage: $PROG [-i file/folder] [-v bitrate] [-a bitrate] [-c vcodec] [-r] [-f] [-m] [-V] [-x] [-h]"
-	cat <<- EOF 
+	cat <<- EOF
 		  Reduce the filesize of a video file to make it stream well. It also
 		  helps with the file size for placing the file into a backup system.
 		  Currently only set up for mp4 files.
-		
+
 		Parameters:
-		  -i input : The input file or folder with which to search for video files. 
+		  -i input : The input file or folder with which to search for video files.
 		             If nothing is provided, current directory (.) is assumed.
 		  -v bitrate : The video bitrate to convert to, defaults to 2000k.
 		  -a bitrate : The audio bitrate to convert to, defaults to 128k.
@@ -64,7 +64,7 @@ while getopts ":i:v:a:c:rfmVxh" opt; do
 	esac
 done
 
-if [[ $set_x == "Y" ]]; then
+if [[ "$set_x" == "Y" ]]; then
 	set -x
 fi
 
@@ -73,23 +73,23 @@ if [[ -z "$input" ]]; then
 	input="."
 fi
 
-if [[ -z $video_bitrate ]]; then
+if [[ -z "$video_bitrate" ]]; then
 	video_bitrate="2000k"
 fi
 
-if [[ -z $audio_bitrate ]]; then
+if [[ -z "$audio_bitrate" ]]; then
 	audio_bitrate="128k"
 fi
 
-if [[ -z $codec ]]; then
+if [[ -z "$codec" ]]; then
 	codec=""
 fi
 
-if [[ -z $search_command ]]; then
+if [[ -z "$search_command" ]]; then
 	search_command="ls"
 fi
 
-if [[ -z $time_command ]]; then
+if [[ -z "$time_command" ]]; then
 	time_command=""
 fi
 
@@ -100,7 +100,7 @@ date_YYYYMMDD="`date "+%Y%m%d"`"
 
 ## Main ##
 
-if [[ $verbose == "Y" ]]; then
+if [[ "$verbose" == "Y" ]]; then
 	cat <<- EOF
 		VERBOSE: Full list of variables.
 		  input='$input'
@@ -122,29 +122,32 @@ SECONDS=0
 $search_command $input | sort | while read file; do
 	echo -e "\n$file"
 
-	if [[ -n $time_command ]]; then
+	if [[ -n "$time_command" ]]; then
 		date
 	fi
 
 	# Exception checks for the existing file.
-	if [[ $file != *'.mp4' ]]; then
+	if [[ "$file" != *'.mp4' ]]; then
 		echo "SKIP: Not an MP4."
 		continue
 	fi
-	if [[ $file == *"$filename_flag"* ]]; then
+	if [[ "$file" == *"$filename_flag"* ]]; then
 		echo "SKIP: Input is already compressed."
 		continue
 	fi
 
-	# Build the new filename to signify it is different thn the original.
-	extension=${file##*.}
-	newfile=${file//$extension/$filename_flag-$date_YYYYMMDD.$extension}
+	# Build the new filename to signify it is different than the original.
+	extension="${file##*.}"
+	newfile="${file//$extension/$filename_flag-$date_YYYYMMDD.$extension}"
+
+	# Convert spaces to underscores.
+	newfile="${newfile// /_}"
 
 	# More exception checks based on the new file.
-	if [[ -e $newfile ]]; then
-		if [[ $force == "Y" ]]; then
+	if [[ -e "$newfile" ]]; then
+		if [[ "$force" == "Y" ]]; then
 			echo "FORCE: Removing $newfile."
-			rm -vf $newfile
+			rm -vf "$newfile"
 		else
 			echo "SKIP: Already has a compressed version ($newfile)."
 			continue
@@ -154,14 +157,14 @@ $search_command $input | sort | while read file; do
 	# Convert the file.
 	echo "Converting to $newfile."
 	$time_command bash -c "ffmpeg -nostdin -hide_banner -loglevel quiet \
-			-i $file -b:v $video_bitrate -b:a $audio_bitrate \
+			-i '$file' -b:v $video_bitrate -b:a $audio_bitrate \
 			$vcodec -movflags +faststart $newfile"
 done
 
 echo "\nDone!"
 
 # Display elapsed time
-if [[ -n $time_command ]]; then
+if [[ -n "$time_command" ]]; then
 	typeset -i hours minutes seconds
 	hours=$(( SECONDS / 3600 ))
 	minutes=$(( (SECONDS % 3600) / 60 ))

--- a/tasks/workstation/shared/settings/gnome.yml
+++ b/tasks/workstation/shared/settings/gnome.yml
@@ -30,7 +30,7 @@
 # Make sure Gnome-Tweaks is installed
 - name: Workstation | Account Management | GNOME | Install Dependencies
   package:
-    name: 
+    name:
       - "{{ gnome_tweaks }}"
       - "{{ dconf_editor }}"
       - "{{ psutil }}"
@@ -48,11 +48,11 @@
     become_user: "{{ user }}"
     register: dash_to_dock_exists
 
-  # Install # 
+  # Install #
   # https://micheleg.github.io/dash-to-dock/download.html
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Install | Clone Repo
-    git: 
+    git:
       repo: https://github.com/micheleg/dash-to-dock.git
       dest: "~/TRASH/dash-to-dock/"
       clone: yes
@@ -63,7 +63,7 @@
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Install | Dependencies
     package:
-      name: 
+      name:
         - "{{ make }}"
         - "{{ msgfmt }}"
         - "{{ sassc }}"
@@ -76,7 +76,7 @@
     when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Read Enabled Extension Array
-    dconf: 
+    dconf:
       key: /org/gnome/shell/enabled-extensions
       state: read
     become_user: "{{ user }}"
@@ -91,7 +91,7 @@
   # https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/playbooks_filters.html#filters-for-formatting-data
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Variables 1
-    set_fact: 
+    set_fact:
       gnome_enabled_extensions: "{{ gnome_enabled_extensions.value | replace('@as ', '') }}"
       dash_to_dock_ext_comma: ""
     when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
@@ -102,12 +102,12 @@
     when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Variables 2
-    set_fact: 
+    set_fact:
       dash_to_dock_ext_comma: ", "
     when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed and gnome_enabled_extensions not in ("[]", [], "None")
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Variables 3
-    set_fact: 
+    set_fact:
       dash_to_dock_ext_name: "{{ dash_to_dock_ext_comma }}'dash-to-dock@micxgx.gmail.com']"
     when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
@@ -132,7 +132,7 @@
     when: ansible_distribution not in ("Ubuntu") and dash_to_dock_exists.failed
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Enable
-    dconf: 
+    dconf:
       key: /org/gnome/shell/enabled-extensions
       value: "{{ gnome_enabled_extensions | replace(']', dash_to_dock_ext_name) }}"
       state: present
@@ -142,34 +142,34 @@
   # Settings #
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Dock Position
-    dconf: 
+    dconf:
       key: /org/gnome/shell/extensions/dash-to-dock/dock-position
       value: "'LEFT'"
       state: present
     become_user: "{{ user }}"
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Dock Fixed
-    dconf: 
+    dconf:
       key: /org/gnome/shell/extensions/dash-to-dock/dock-fixed
       value: "true"
       state: present
     become_user: "{{ user }}"
 
   - name: Workstation | Account Management | GNOME | Dash To Dock | Icon Size
-    dconf: 
+    dconf:
       key: /org/gnome/shell/extensions/dash-to-dock/dash-max-icon-size
       value: "28"
       state: present
     become_user: "{{ user }}"
-    
+
   ignore_errors: yes
 
 - name: Workstation | Account Management | GNOME + Cinnamon | Favorites (Linux)
-  dconf: 
+  dconf:
     key: "{{ item }}"
     value: "[ 'org.gnome.Terminal.desktop', 'gnome-system-monitor.desktop'
             , 'org.gnome.Nautilus.desktop'
-            , 'io.gitlab.librewolf-community.desktop', '{{ browser }}'
+            , 'io.gitlab.librewolf-community.desktop'
             , 'org.gnome.Evolution.desktop', 'chat.delta.desktop.desktop'
             , 'com.vscodium.codium.desktop', 'org.shotcut.Shotcut.desktop'
             , 'io.lbry.lbry-app.desktop'
@@ -182,18 +182,18 @@
   when: ansible_system == "Linux"
   loop:
     - /org/gnome/shell/favorite-apps
-    - /org/cinnamon/favorite-apps 
-  # As of 2023-07-01 this only sets the Menu Favorites on Cinnamon, not the 
+    - /org/cinnamon/favorite-apps
+  # As of 2023-07-01 this only sets the Menu Favorites on Cinnamon, not the
   #  Panel Pins. Cannot find any details online of where the pinned application
   #  data lives. Cloned and searched the linuxmint/cinnamon project too and
   #  couldn't find which function handles it. Leaving the loop for it but it's
   #  not what was hoped for and is sort of a TBD/TODO.
-  
+
 - name: Workstation | Account Management | GNOME | Favorites (FreeBSD)
-  dconf: 
+  dconf:
     key: /org/gnome/shell/favorite-apps
-    value: "['org.gnome.Terminal.desktop', 'org.gnome.Nautilus.desktop', 
-             'firefox.desktop', 'org.gnome.Evolution.desktop', 'org.mozilla.Thunderbird.desktop', 
+    value: "['org.gnome.Terminal.desktop', 'org.gnome.Nautilus.desktop',
+             'firefox.desktop', 'org.gnome.Evolution.desktop', 'org.mozilla.Thunderbird.desktop',
              'code-oss.desktop', 'org.telegram.desktop.desktop']"
     state: present
   become_user: "{{ user }}"
@@ -204,42 +204,42 @@
 # (Battery Percentage, Clock Weekday+Seconds, Calendar Week Numbers)
 
 - name: Workstation | Account Management | GNOME | Interface - Show Date
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/interface/clock-show-date
     value: "true"
     state: present
   become_user: "{{ user }}"
 
 - name: Workstation | Account Management | GNOME | Interface - 24h Format
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/interface/clock-format
     value: "'24h'"
     state: present
   become_user: "{{ user }}"
 
 - name: Workstation | Account Management | GNOME | Interface - Show Seconds
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/interface/clock-show-seconds
     value: "true"
     state: present
   become_user: "{{ user }}"
 
 - name: Workstation | Account Management | GNOME | Interface - Show Weekday
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/interface/clock-show-weekday
     value: "true"
     state: present
   become_user: "{{ user }}"
 
 - name: Workstation | Account Management | GNOME | Interface - 24h Format
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/interface/show-battery-percentage
     value: "true"
     state: present
   become_user: "{{ user }}"
 
 - name: Workstation | Account Management | GNOME | Interface - Show Week Date
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/calendar/show-weekdate
     value: "true"
     state: present
@@ -258,8 +258,8 @@
 
 # Window Titlebars (Titlebar Buttons Minimize)
 - name: Workstation | Account Management | GNOME | Window Buttons
-  dconf: 
-    key: /org/gnome/desktop/wm/preferences/button-layout 
+  dconf:
+    key: /org/gnome/desktop/wm/preferences/button-layout
     value: "'appmenu:minimize,close'"
     state: present
   become_user: "{{ user }}"
@@ -267,14 +267,14 @@
 
 # Security
 - name: Workstation | Account Management | GNOME | Privacy - Camera
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/privacy/disable-camera
     value: "true"
     state: present
   become_user: "{{ user }}"
 
 - name: Workstation | Account Management | GNOME | Privacy - Microphone
-  dconf: 
+  dconf:
     key: /org/gnome/desktop/privacy/disable-microphone
     value: "true"
     state: present


### PR DESCRIPTION
Stop using Chromium-based browsers by default.

Allow video compression script to handle files with spaces in them.