### PR TITLE
Hotfix for RC Files

### DIFF
--- a/facts/general/package.yml
+++ b/facts/general/package.yml
@@ -265,5 +265,5 @@
 - name: General | Facts | Package | Update Command | Firmware | Missing
   set_fact:
     update_firmware: |
-      echo "*** Firmware Updater (fwupdmgr) Not Installed ***" &&
+      echo "*** Firmware Updater (fwupdmgr) Not Installed ***"
   when: update_firmware is not defined

--- a/facts/general/package.yml
+++ b/facts/general/package.yml
@@ -241,7 +241,7 @@
 - name: General | Facts | Package | Update Command | Flatpak | Missing
   set_fact:
     update_flatpak: |
-      echo "*** Flatpak Not Installed ***" &&
+      echo "*** Flatpak Not Installed ***"
   when: update_flatpak is not defined
 
 # Firmware


### PR DESCRIPTION
Code was tested on systems with Flatpak -- servers started having an issue with the && not being followed by code, only a `fi`, and could no longer load `.bashrc`..